### PR TITLE
WIP: Fix issue with absence of cmath in stdlib of python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ ENV FREECAD_REPO git://github.com/FreeCAD/FreeCAD.git
 FROM base as builder
 RUN \
     pack_build="git \
-                python$PYTHON_MINOR_VERSION \
-                python$PYTHON_MINOR_VERSION-dev \
                 wget \
                 build-essential \
                 cmake \
@@ -46,13 +44,54 @@ RUN \
                 netgen-headers \
                 libmedc-dev \
                 libvtk6-dev \
+                libffi-dev \
                 libproj-dev \
                 gmsh " \
     && apt update \
     && apt install -y --no-install-recommends software-properties-common \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y --no-install-recommends $pack_build
+
+
+FROM builder AS python_builder
+
+ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+
+RUN set -ex \
+	\
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make install \
+	&& ldconfig \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python \
+	\
+	&& python3 --version
 
 RUN set -ex; \
     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,10 @@ RUN set -ex; \
         \) -exec rm -rf '{}' +; \
     rm -f get-pip.py
 
+RUN cd /usr/local/bin \
+	&& ln -s python3 python
+
+
 FROM python_builder AS clone_freecad
 # get FreeCAD Git
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,12 +112,18 @@ RUN set -ex; \
         \) -exec rm -rf '{}' +; \
     rm -f get-pip.py
 
+FROM python_builder AS clone_freecad
+# get FreeCAD Git
+RUN \
+    cd \
+    && git clone --branch "$FREECAD_VERSION" "$FREECAD_REPO"
+
+FROM clone_freecad AS compile_fc
+
 ENV PYTHONPATH "/usr/local/lib:$PYTHONPATH"
 
 RUN \
-  # get FreeCAD Git
     cd \
-    && git clone --branch "$FREECAD_VERSION" "$FREECAD_REPO" \
     && mkdir freecad-build \
     && cd freecad-build \
   # Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04 AS base
 MAINTAINER Sviatoslav Sydorenko <wk+freecad-cli-py3.7-docker@sydorenko.org.ua>
 
 ENV PYTHON_VERSION 3.7.0
@@ -11,7 +11,7 @@ ENV PYTHON_PIP_VERSION 18.0
 ENV FREECAD_VERSION master
 ENV FREECAD_REPO git://github.com/FreeCAD/FreeCAD.git
 
-
+FROM base as builder
 RUN \
     pack_build="git \
                 python$PYTHON_MINOR_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:16.04 AS base
 MAINTAINER Sviatoslav Sydorenko <wk+freecad-cli-py3.7-docker@sydorenko.org.ua>
 
-ENV PYTHON_VERSION 3.7.0
+ENV PYTHON_VERSION 3.7.2
 ENV PYTHON_MINOR_VERSION 3.7
 ENV PYTHON_SUFFIX_VERSION .cpython-37m
 ENV PYTHON_BIN_VERSION python3.7m
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 18.0
+ENV PYTHON_PIP_VERSION 18.1
 
 ENV FREECAD_VERSION master
 ENV FREECAD_REPO git://github.com/FreeCAD/FreeCAD.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ ENV PYTHON_PIP_VERSION 18.1
 ENV FREECAD_VERSION master
 ENV FREECAD_REPO git://github.com/FreeCAD/FreeCAD.git
 
+
+
 FROM base as builder
+
 RUN \
     pack_build="git \
                 wget \
@@ -51,6 +54,7 @@ RUN \
     && apt install -y --no-install-recommends software-properties-common \
     && apt update \
     && apt install -y --no-install-recommends $pack_build
+
 
 
 FROM builder AS python_builder
@@ -116,11 +120,15 @@ RUN cd /usr/local/bin \
 	&& ln -s python3 python
 
 
+
 FROM python_builder AS clone_freecad
 # get FreeCAD Git
+
 RUN \
     cd \
     && git clone --branch "$FREECAD_VERSION" "$FREECAD_REPO"
+
+
 
 FROM clone_freecad AS compile_fc
 


### PR DESCRIPTION
Resolves the issue with the absence of cmath module in the python provided by ppa:deadsnakes/ppa. See discussion on https://stackoverflow.com/questions/51707435/python-3-7-cmath-module-import-error . Freecad depends on this lib and through the error ModuleNotFound.

The solution proposed in this MR is to compile the python from the source.

Also, this MR uses multi-staging build